### PR TITLE
fix(dynamicWatcher): watchDelegate.length check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "iojs"
+  - "0.12"
 
 branches:
   only:

--- a/src/bindNotifier.js
+++ b/src/bindNotifier.js
@@ -62,8 +62,15 @@
     function wrap (watchDelegate, scope, listener, objectEquality, parsedExpression) {
       var delegateCall = watchDelegate.bind(this, scope, listener, objectEquality, parsedExpression);
 
-      // In a nutshell; If of type 'oneTimeWatchDelegate', add $on listeners.
-      if (/oneTimeWatchDelegate/.test(watchDelegate.toString())) {
+      /**
+       * In a nutshell; If the amount of expected arguments of watchDelegate
+       * is over 0 - we are not dealing with a oneTimeWatchDelegate, and as such
+       * we should not setup new listeners.
+       *
+       * #yuck
+       */
+
+      if (watchDelegate.length > 0) {
         setupListeners(scope, delegateCall);
       }
 


### PR DESCRIPTION
Checking the name of the watchDelegate does not play well with a minified source. Checking the length of the given watchDelegate (the amount of parameters), we can rule out cases where we are not dealing with a oneTimeWatchDelegate. 

A better solution to this problem *has* to be be out there, somewhere. 

![yuck](http://vignette4.wikia.nocookie.net/meme/images/6/6a/YUCK_MEME.jpg/revision/latest?cb=20120726062354)

--- 

Closes #14 