### PR TITLE
Handle ternary operators and angular filters with arguments

### DIFF
--- a/src/bindNotifier.js
+++ b/src/bindNotifier.js
@@ -113,7 +113,7 @@
           while (parts.length) {
             part = parts.shift();
             if (part) {
-              if (/^\s*[\{\[]/.test(part)) {
+              if (!/^\w+$/.test(part)) {
                 rawExpression = [part].concat(parts).join(':');
                 break;
               }


### PR DESCRIPTION
The current version doesn't allow to use the angular-bind-notifier with **ternary operators** and **filters with arguments**.

First case, **ternary operators** :
`{{:namespace:(varA?varB:varC)}}`
`varA?varB` is not a namespace, it is part of the expression.

Other case, **filters with arguments** :
`{{:namespace:(varA|orderBy:varB:varC)}}`
`(varA|orderBy` is not a namespace, it is part of the expression.

