### PR TITLE
Change logic for detecting keys in an expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Possible use cases include but are not limited to;
 * Model data that changes seldomly, that then needs to be reflected in the view.
 * Translation(s) of the entire page (or a subsection), where static data needs to be re-translated.
 
+Keys are determined by the following rules:
+
+- surrounded by `:` character
+- consists only of alphanumeric characters and `-`
+- cannot start with a `-`
+- is at the start of the binding or follows another key
+
+For example: in `:keyOne:key-2:3:variable | someFilter:true:10` the following are keys: `keyOne`, `key-2`, `3` and the 
+remaining contents are the expression due to `variable | someFilter` not matching the rules of being a key
+
 ## usage
 ```js
 // inject the module dependency

--- a/test/bindNotifierKeyRegex.spec.js
+++ b/test/bindNotifierKeyRegex.spec.js
@@ -1,0 +1,38 @@
+(function () {
+
+  'use strict';
+
+  describe('bindNotifier key regex', function () {
+    var subject;
+
+    beforeEach(function () {
+      module('angular.bind.notifier');
+
+      inject(function ($injector) {
+        subject = $injector.get('bindNotifierKeyRegex');
+      });
+    });
+
+    it('is defined', function () {
+      expect(!!subject).to.be.true;
+    });
+
+    ['regularKey', '99numberStart', 'allows-dashes', 'CAPITALSAREFINE'].forEach(isMatch);
+    ['-noStartingDash', 'contains!InvalidChar', '_invalidChar', '', ' initialWhitespace', 'endingWhitespace ',
+      'middle whitespace', '{ object: \'expression\' }', 'ternary ? \'statements\' : \'fail\'', 'property.access'].forEach(isNotMatch);
+
+    // Helpers
+    function isMatch (value) {
+      it('matches ' + value, function () {
+        expect(subject.test(value)).to.be.true;
+      });
+    }
+
+    function isNotMatch (value) {
+      it('does not match ' + value, function () {
+        expect(subject.test(value)).to.be.false;
+      });
+    }
+  });
+
+}());


### PR DESCRIPTION
Changes how keys are detected so more expressions are able to work.

Example: `:key:variable | filter:filterOption`

### Current behaviour:
binds to `filterOption` with notifiers `key`, `variable | filter`

### New behaviour:

binds to `variable | filter:filterOption` with notifier `key` 

# Changes:

Keys are restricted to anything that matches `^[a-zA-Z0-9][\w-]*$` (alphanumeric with - allowed after first character). Old logic still applies. The current bindNotifierRegex already kind of enforces this naming scheme

# ~~Alternative:~~

~~An alternative solution to the problem could be that keys are defined in the initial set of `:` comma separated. i.e. `:key1,key2,key3:variable | filter:filterOptions` but would be a major breaking change~~